### PR TITLE
schema: treat xsd:integer as 64 bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ is to get documents working well, then spreadsheets, and finally presentations.
 ## Installation ##
     
     go get baliance.com/gooxml/
-    go build baliance.com/gooxml/...
+    go build -i baliance.com/gooxml/...
 
 ## Raw Types ##
 

--- a/document/numbering.go
+++ b/document/numbering.go
@@ -48,7 +48,7 @@ func (n Numbering) InitializeDefault() {
 	const indentDelta = 144
 	for i := 0; i < 9; i++ {
 		lvl := wml.NewCT_Lvl()
-		lvl.IlvlAttr = int32(i)
+		lvl.IlvlAttr = int64(i)
 		lvl.Start = wml.NewCT_DecimalNumber()
 		lvl.Start.ValAttr = 1
 
@@ -72,12 +72,12 @@ func (n Numbering) InitializeDefault() {
 		tab := wml.NewCT_TabStop()
 		tab.ValAttr = wml.ST_TabJcNum
 
-		indent := int32(i*indentDelta + indentStart)
-		tab.PosAttr.Int32 = gooxml.Int32(indent)
+		indent := int64(i*indentDelta + indentStart)
+		tab.PosAttr.Int64 = gooxml.Int64(indent)
 		lvl.PPr.Tabs.Tab = append(lvl.PPr.Tabs.Tab, tab)
 		lvl.PPr.Ind = wml.NewCT_Ind()
 		lvl.PPr.Ind.LeftAttr = &wml.ST_SignedTwipsMeasure{}
-		lvl.PPr.Ind.LeftAttr.Int32 = gooxml.Int32(indent)
+		lvl.PPr.Ind.LeftAttr.Int64 = gooxml.Int64(indent)
 		lvl.PPr.Ind.HangingAttr = &sharedTypes.ST_TwipsMeasure{}
 		lvl.PPr.Ind.HangingAttr.ST_UnsignedDecimalNumber = gooxml.Uint64(uint64(indent))
 

--- a/document/paragraph.go
+++ b/document/paragraph.go
@@ -63,7 +63,7 @@ func (p Paragraph) AddTabStop(position measurement.Distance, justificaton wml.ST
 	tab := wml.NewCT_TabStop()
 	tab.LeaderAttr = leader
 	tab.ValAttr = justificaton
-	tab.PosAttr.Int32 = gooxml.Int32(int32(position / measurement.Twips))
+	tab.PosAttr.Int64 = gooxml.Int64(int64(position / measurement.Twips))
 	p.x.PPr.Tabs.Tab = append(p.x.PPr.Tabs.Tab, tab)
 }
 
@@ -120,7 +120,7 @@ func (p Paragraph) SetHeadingLevel(idx int) {
 		p.x.PPr.NumPr = wml.NewCT_NumPr()
 	}
 	p.x.PPr.NumPr.Ilvl = wml.NewCT_DecimalNumber()
-	p.x.PPr.NumPr.Ilvl.ValAttr = int32(idx)
+	p.x.PPr.NumPr.Ilvl.ValAttr = int64(idx)
 	p.x.PPr.NumPr.NumId = wml.NewCT_DecimalNumber()
-	p.x.PPr.NumPr.NumId.ValAttr = int32(1)
+	p.x.PPr.NumPr.NumId.ValAttr = int64(1)
 }

--- a/document/paragraphstyle.go
+++ b/document/paragraphstyle.go
@@ -31,7 +31,7 @@ func (p ParagraphStyle) AddTabStop(position measurement.Distance, justificaton w
 	tab := wml.NewCT_TabStop()
 	tab.LeaderAttr = leader
 	tab.ValAttr = justificaton
-	tab.PosAttr.Int32 = gooxml.Int32(int32(position / measurement.Twips))
+	tab.PosAttr.Int64 = gooxml.Int64(int64(position / measurement.Twips))
 	p.x.Tabs.Tab = append(p.x.Tabs.Tab, tab)
 }
 
@@ -68,5 +68,5 @@ func (p ParagraphStyle) SetKeepNext(b bool) {
 // SetOutlineLevel sets the outline level of this style.
 func (p ParagraphStyle) SetOutlineLevel(lvl int) {
 	p.x.OutlineLvl = wml.NewCT_DecimalNumber()
-	p.x.OutlineLvl.ValAttr = int32(lvl)
+	p.x.OutlineLvl.ValAttr = int64(lvl)
 }

--- a/document/style.go
+++ b/document/style.go
@@ -60,7 +60,7 @@ func (s Style) SetPrimaryStyle(b bool) {
 // SetUISortOrder controls the order the style is displayed in the UI.
 func (s Style) SetUISortOrder(order int) {
 	s.x.UiPriority = wml.NewCT_DecimalNumber()
-	s.x.UiPriority.ValAttr = int32(order)
+	s.x.UiPriority.ValAttr = int64(order)
 }
 
 // SetSemiHidden controls if the style is hidden in the UI.

--- a/document/styles.go
+++ b/document/styles.go
@@ -203,7 +203,7 @@ func (s Styles) initializeDocDefaults() {
 	s.x.DocDefaults.PPrDefault.PPr.Spacing.AfterAttr = &sharedTypes.ST_TwipsMeasure{}
 	s.x.DocDefaults.PPrDefault.PPr.Spacing.AfterAttr.ST_UnsignedDecimalNumber = gooxml.Uint64(160)
 	s.x.DocDefaults.PPrDefault.PPr.Spacing.LineAttr = &wml.ST_SignedTwipsMeasure{}
-	s.x.DocDefaults.PPrDefault.PPr.Spacing.LineAttr.Int32 = gooxml.Int32(259)
+	s.x.DocDefaults.PPrDefault.PPr.Spacing.LineAttr.Int64 = gooxml.Int64(259)
 	s.x.DocDefaults.PPrDefault.PPr.Spacing.LineRuleAttr = wml.ST_LineSpacingRuleAuto
 }
 

--- a/document/table.go
+++ b/document/table.go
@@ -53,7 +53,7 @@ func (t Table) SetWidthPercent(v float64) {
 	t.x.TblPr.TblW.WAttr = &wml.ST_MeasurementOrPercent{}
 	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent = &wml.ST_DecimalNumberOrPercent{}
 	// percent value is measured in 1/50'th of a percent
-	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int32(int32(v * 50))
+	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int64(int64(v * 50))
 }
 
 func (t Table) SetWidth(d measurement.Distance) {
@@ -62,7 +62,7 @@ func (t Table) SetWidth(d measurement.Distance) {
 	t.x.TblPr.TblW.TypeAttr = wml.ST_TblWidthDxa
 	t.x.TblPr.TblW.WAttr = &wml.ST_MeasurementOrPercent{}
 	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent = &wml.ST_DecimalNumberOrPercent{}
-	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int32(int32(d / measurement.Twips))
+	t.x.TblPr.TblW.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int64(int64(d / measurement.Twips))
 }
 
 func (t Table) Borders() Borders {

--- a/document/tablewidth.go
+++ b/document/tablewidth.go
@@ -32,6 +32,6 @@ func (s TableWidth) X() *wml.CT_TblWidth {
 func (s TableWidth) SetValue(m measurement.Distance) {
 	s.x.WAttr = &wml.ST_MeasurementOrPercent{}
 	s.x.WAttr.ST_DecimalNumberOrPercent = &wml.ST_DecimalNumberOrPercent{}
-	s.x.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int32(int32(m / measurement.Twips))
+	s.x.WAttr.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = gooxml.Int64(int64(m / measurement.Twips))
 	s.x.TypeAttr = wml.ST_TblWidthDxa
 }

--- a/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_Integer2.go
+++ b/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_Integer2.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CT_Integer2 struct {
-	ValAttr int32
+	ValAttr int64
 }
 
 func NewCT_Integer2() *CT_Integer2 {
@@ -38,11 +38,11 @@ func (m *CT_Integer2) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	m.ValAttr = -2
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "val" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.ValAttr = int32(parsed)
+			m.ValAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_Integer255.go
+++ b/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_Integer255.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CT_Integer255 struct {
-	ValAttr int32
+	ValAttr int64
 }
 
 func NewCT_Integer255() *CT_Integer255 {
@@ -38,11 +38,11 @@ func (m *CT_Integer255) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	m.ValAttr = 1
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "val" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.ValAttr = int32(parsed)
+			m.ValAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_ManualBreak.go
+++ b/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_ManualBreak.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CT_ManualBreak struct {
-	AlnAtAttr *int32
+	AlnAtAttr *int64
 }
 
 func NewCT_ManualBreak() *CT_ManualBreak {
@@ -38,12 +38,11 @@ func (m *CT_ManualBreak) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "alnAt" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.AlnAtAttr = &pt
+			m.AlnAtAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_SpacingRule.go
+++ b/schema/schemas.openxmlformats.org/officeDocument/2006/math/CT_SpacingRule.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CT_SpacingRule struct {
-	ValAttr int32
+	ValAttr int64
 }
 
 func NewCT_SpacingRule() *CT_SpacingRule {
@@ -38,11 +38,11 @@ func (m *CT_SpacingRule) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	m.ValAttr = 0
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "val" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.ValAttr = int32(parsed)
+			m.ValAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/spreadsheetml/CT_FontFamily.go
+++ b/schema/schemas.openxmlformats.org/spreadsheetml/CT_FontFamily.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CT_FontFamily struct {
-	ValAttr int32
+	ValAttr int64
 }
 
 func NewCT_FontFamily() *CT_FontFamily {
@@ -38,11 +38,11 @@ func (m *CT_FontFamily) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	m.ValAttr = 0
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "val" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.ValAttr = int32(parsed)
+			m.ValAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/AG_Password.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/AG_Password.go
@@ -17,7 +17,7 @@ type AG_Password struct {
 	AlgorithmNameAttr *string
 	HashValueAttr     *string
 	SaltValueAttr     *string
-	SpinCountAttr     *int32
+	SpinCountAttr     *int64
 }
 
 func NewAG_Password() *AG_Password {
@@ -72,12 +72,11 @@ func (m *AG_Password) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 			m.SaltValueAttr = &parsed
 		}
 		if attr.Name.Local == "spinCount" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.SpinCountAttr = &pt
+			m.SpinCountAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/AG_TransitionalPassword.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/AG_TransitionalPassword.go
@@ -19,8 +19,8 @@ type AG_TransitionalPassword struct {
 	CryptProviderTypeAttr          sharedTypes.ST_CryptProv
 	CryptAlgorithmClassAttr        sharedTypes.ST_AlgClass
 	CryptAlgorithmTypeAttr         sharedTypes.ST_AlgType
-	CryptAlgorithmSidAttr          *int32
-	CryptSpinCountAttr             *int32
+	CryptAlgorithmSidAttr          *int64
+	CryptSpinCountAttr             *int64
 	CryptProviderAttr              *string
 	AlgIdExtAttr                   *string
 	AlgIdExtSourceAttr             *string
@@ -110,20 +110,18 @@ func (m *AG_TransitionalPassword) UnmarshalXML(d *xml.Decoder, start xml.StartEl
 			m.CryptAlgorithmTypeAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "cryptAlgorithmSid" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptAlgorithmSidAttr = &pt
+			m.CryptAlgorithmSidAttr = &parsed
 		}
 		if attr.Name.Local == "cryptSpinCount" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptSpinCountAttr = &pt
+			m.CryptSpinCountAttr = &parsed
 		}
 		if attr.Name.Local == "cryptProvider" {
 			parsed, err := attr.Value, error(nil)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_AbstractNum.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_AbstractNum.go
@@ -16,7 +16,7 @@ import (
 
 type CT_AbstractNum struct {
 	// Abstract Numbering Definition ID
-	AbstractNumIdAttr int32
+	AbstractNumIdAttr int64
 	// Abstract Numbering Definition Identifier
 	Nsid *CT_LongHexNumber
 	// Abstract Numbering Definition Type
@@ -80,11 +80,11 @@ func (m *CT_AbstractNum) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "abstractNumId" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.AbstractNumIdAttr = int32(parsed)
+			m.AbstractNumIdAttr = parsed
 		}
 	}
 lCT_AbstractNum:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Bookmark.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Bookmark.go
@@ -15,11 +15,11 @@ import (
 
 type CT_Bookmark struct {
 	NameAttr                 string
-	ColFirstAttr             *int32
-	ColLastAttr              *int32
+	ColFirstAttr             *int64
+	ColLastAttr              *int64
 	DisplacedByCustomXmlAttr ST_DisplacedByCustomXml
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_Bookmark() *CT_Bookmark {
@@ -65,30 +65,28 @@ func (m *CT_Bookmark) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 			m.NameAttr = parsed
 		}
 		if attr.Name.Local == "colFirst" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColFirstAttr = &pt
+			m.ColFirstAttr = &parsed
 		}
 		if attr.Name.Local == "colLast" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColLastAttr = &pt
+			m.ColLastAttr = &parsed
 		}
 		if attr.Name.Local == "displacedByCustomXml" {
 			m.DisplacedByCustomXmlAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_BookmarkRange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_BookmarkRange.go
@@ -14,11 +14,11 @@ import (
 )
 
 type CT_BookmarkRange struct {
-	ColFirstAttr             *int32
-	ColLastAttr              *int32
+	ColFirstAttr             *int64
+	ColLastAttr              *int64
 	DisplacedByCustomXmlAttr ST_DisplacedByCustomXml
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_BookmarkRange() *CT_BookmarkRange {
@@ -55,30 +55,28 @@ func (m *CT_BookmarkRange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "colFirst" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColFirstAttr = &pt
+			m.ColFirstAttr = &parsed
 		}
 		if attr.Name.Local == "colLast" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColLastAttr = &pt
+			m.ColLastAttr = &parsed
 		}
 		if attr.Name.Local == "displacedByCustomXml" {
 			m.DisplacedByCustomXmlAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Caption.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Caption.go
@@ -23,7 +23,7 @@ type CT_Caption struct {
 	// Include Chapter Number in Field for Caption
 	ChapNumAttr *sharedTypes.ST_OnOff
 	// Style for Chapter Headings
-	HeadingAttr *int32
+	HeadingAttr *int64
 	// Do Not Include Name In Caption
 	NoLabelAttr *sharedTypes.ST_OnOff
 	// Caption Numbering Format
@@ -101,12 +101,11 @@ func (m *CT_Caption) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.ChapNumAttr = &parsed
 		}
 		if attr.Name.Local == "heading" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.HeadingAttr = &pt
+			m.HeadingAttr = &parsed
 		}
 		if attr.Name.Local == "noLabel" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_CellMergeTrackChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_CellMergeTrackChange.go
@@ -20,7 +20,7 @@ type CT_CellMergeTrackChange struct {
 	AuthorAttr     string
 	DateAttr       *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_CellMergeTrackChange() *CT_CellMergeTrackChange {
@@ -82,11 +82,11 @@ func (m *CT_CellMergeTrackChange) UnmarshalXML(d *xml.Decoder, start xml.StartEl
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Columns.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Columns.go
@@ -22,7 +22,7 @@ type CT_Columns struct {
 	// Spacing Between Equal Width Columns
 	SpaceAttr *sharedTypes.ST_TwipsMeasure
 	// Number of Equal Width Columns
-	NumAttr *int32
+	NumAttr *int64
 	// Draw Line Between Columns
 	SepAttr *sharedTypes.ST_OnOff
 	// Single Column Definition
@@ -78,12 +78,11 @@ func (m *CT_Columns) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.SpaceAttr = &parsed
 		}
 		if attr.Name.Local == "num" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.NumAttr = &pt
+			m.NumAttr = &parsed
 		}
 		if attr.Name.Local == "sep" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Comment.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Comment.go
@@ -22,7 +22,7 @@ type CT_Comment struct {
 	AuthorAttr   string
 	DateAttr     *time.Time
 	// Annotation Identifier
-	IdAttr            int32
+	IdAttr            int64
 	EG_BlockLevelElts []*EG_BlockLevelElts
 }
 
@@ -81,11 +81,11 @@ func (m *CT_Comment) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_Comment:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_DecimalNumber.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_DecimalNumber.go
@@ -15,7 +15,7 @@ import (
 
 type CT_DecimalNumber struct {
 	// Decimal Number Value
-	ValAttr int32
+	ValAttr int64
 }
 
 func NewCT_DecimalNumber() *CT_DecimalNumber {
@@ -37,11 +37,11 @@ func (m *CT_DecimalNumber) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "val" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.ValAttr = int32(parsed)
+			m.ValAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Div.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Div.go
@@ -16,7 +16,7 @@ import (
 
 type CT_Div struct {
 	// div Data ID
-	IdAttr int32
+	IdAttr int64
 	// Data for HTML blockquote Element
 	BlockQuote *CT_OnOff
 	// Data for HTML body Element
@@ -86,11 +86,11 @@ func (m *CT_Div) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	m.MarBottom = NewCT_SignedTwipsMeasure()
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_Div:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_DocGrid.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_DocGrid.go
@@ -17,9 +17,9 @@ type CT_DocGrid struct {
 	// Document Grid Type
 	TypeAttr ST_DocGrid
 	// Document Grid Line Pitch
-	LinePitchAttr *int32
+	LinePitchAttr *int64
 	// Document Grid Character Pitch
-	CharSpaceAttr *int32
+	CharSpaceAttr *int64
 }
 
 func NewCT_DocGrid() *CT_DocGrid {
@@ -57,20 +57,18 @@ func (m *CT_DocGrid) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.TypeAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "linePitch" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.LinePitchAttr = &pt
+			m.LinePitchAttr = &parsed
 		}
 		if attr.Name.Local == "charSpace" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CharSpaceAttr = &pt
+			m.CharSpaceAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_DocProtect.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_DocProtect.go
@@ -25,8 +25,8 @@ type CT_DocProtect struct {
 	CryptProviderTypeAttr          sharedTypes.ST_CryptProv
 	CryptAlgorithmClassAttr        sharedTypes.ST_AlgClass
 	CryptAlgorithmTypeAttr         sharedTypes.ST_AlgType
-	CryptAlgorithmSidAttr          *int32
-	CryptSpinCountAttr             *int32
+	CryptAlgorithmSidAttr          *int64
+	CryptSpinCountAttr             *int64
 	CryptProviderAttr              *string
 	AlgIdExtAttr                   *string
 	AlgIdExtSourceAttr             *string
@@ -151,20 +151,18 @@ func (m *CT_DocProtect) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 			m.CryptAlgorithmTypeAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "cryptAlgorithmSid" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptAlgorithmSidAttr = &pt
+			m.CryptAlgorithmSidAttr = &parsed
 		}
 		if attr.Name.Local == "cryptSpinCount" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptSpinCountAttr = &pt
+			m.CryptSpinCountAttr = &parsed
 		}
 		if attr.Name.Local == "cryptProvider" {
 			parsed, err := attr.Value, error(nil)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_EastAsianLayout.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_EastAsianLayout.go
@@ -17,7 +17,7 @@ import (
 
 type CT_EastAsianLayout struct {
 	// East Asian Typography Run ID
-	IdAttr *int32
+	IdAttr *int64
 	// Two Lines in One
 	CombineAttr *sharedTypes.ST_OnOff
 	// Display Brackets Around Two Lines in One
@@ -68,12 +68,11 @@ func (m *CT_EastAsianLayout) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.IdAttr = &pt
+			m.IdAttr = &parsed
 		}
 		if attr.Name.Local == "combine" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_FitText.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_FitText.go
@@ -19,7 +19,7 @@ type CT_FitText struct {
 	// Value
 	ValAttr sharedTypes.ST_TwipsMeasure
 	// Fit Text Run ID
-	IdAttr *int32
+	IdAttr *int64
 }
 
 func NewCT_FitText() *CT_FitText {
@@ -52,12 +52,11 @@ func (m *CT_FitText) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.ValAttr = parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.IdAttr = &pt
+			m.IdAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_FramePr.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_FramePr.go
@@ -19,7 +19,7 @@ type CT_FramePr struct {
 	// Drop Cap Frame
 	DropCapAttr ST_DropCap
 	// Drop Cap Vertical Height in Lines
-	LinesAttr *int32
+	LinesAttr *int64
 	// Frame Width
 	WAttr *sharedTypes.ST_TwipsMeasure
 	// Frame Height
@@ -149,12 +149,11 @@ func (m *CT_FramePr) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.DropCapAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "lines" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.LinesAttr = &pt
+			m.LinesAttr = &parsed
 		}
 		if attr.Name.Local == "w" {
 			parsed, err := ParseUnionST_TwipsMeasure(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdn.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdn.go
@@ -20,7 +20,7 @@ type CT_FtnEdn struct {
 	// Footnote/Endnote Type
 	TypeAttr ST_FtnEdn
 	// Footnote/Endnote ID
-	IdAttr            int32
+	IdAttr            int64
 	EG_BlockLevelElts []*EG_BlockLevelElts
 }
 
@@ -56,11 +56,11 @@ func (m *CT_FtnEdn) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.TypeAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_FtnEdn:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdnRef.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdnRef.go
@@ -19,7 +19,7 @@ type CT_FtnEdnRef struct {
 	// Suppress Footnote/Endnote Reference Mark
 	CustomMarkFollowsAttr *sharedTypes.ST_OnOff
 	// Footnote/Endnote ID Reference
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_FtnEdnRef() *CT_FtnEdnRef {
@@ -52,11 +52,11 @@ func (m *CT_FtnEdnRef) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 			m.CustomMarkFollowsAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdnSepRef.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_FtnEdnSepRef.go
@@ -15,7 +15,7 @@ import (
 
 type CT_FtnEdnSepRef struct {
 	// Footnote/Endnote ID
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_FtnEdnSepRef() *CT_FtnEdnSepRef {
@@ -37,11 +37,11 @@ func (m *CT_FtnEdnSepRef) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Ind.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Ind.go
@@ -19,27 +19,27 @@ type CT_Ind struct {
 	// Start Indentation
 	StartAttr *ST_SignedTwipsMeasure
 	// Start Indentation in Character Units
-	StartCharsAttr *int32
+	StartCharsAttr *int64
 	// End Indentation
 	EndAttr *ST_SignedTwipsMeasure
 	// End Indentation in Character Units
-	EndCharsAttr *int32
+	EndCharsAttr *int64
 	// Start Indentation
 	LeftAttr *ST_SignedTwipsMeasure
 	// Start Indentation in Character Units
-	LeftCharsAttr *int32
+	LeftCharsAttr *int64
 	// End Indentation
 	RightAttr *ST_SignedTwipsMeasure
 	// End Indentation in Character Units
-	RightCharsAttr *int32
+	RightCharsAttr *int64
 	// Indentation Removed from First Line
 	HangingAttr *sharedTypes.ST_TwipsMeasure
 	// Indentation Removed From First Line in Character Units
-	HangingCharsAttr *int32
+	HangingCharsAttr *int64
 	// Additional First Line Indentation
 	FirstLineAttr *sharedTypes.ST_TwipsMeasure
 	// Additional First Line Indentation in Character Units
-	FirstLineCharsAttr *int32
+	FirstLineCharsAttr *int64
 }
 
 func NewCT_Ind() *CT_Ind {
@@ -114,12 +114,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.StartAttr = &parsed
 		}
 		if attr.Name.Local == "startChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.StartCharsAttr = &pt
+			m.StartCharsAttr = &parsed
 		}
 		if attr.Name.Local == "end" {
 			parsed, err := ParseUnionST_SignedTwipsMeasure(attr.Value)
@@ -129,12 +128,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.EndAttr = &parsed
 		}
 		if attr.Name.Local == "endChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.EndCharsAttr = &pt
+			m.EndCharsAttr = &parsed
 		}
 		if attr.Name.Local == "left" {
 			parsed, err := ParseUnionST_SignedTwipsMeasure(attr.Value)
@@ -144,12 +142,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.LeftAttr = &parsed
 		}
 		if attr.Name.Local == "leftChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.LeftCharsAttr = &pt
+			m.LeftCharsAttr = &parsed
 		}
 		if attr.Name.Local == "right" {
 			parsed, err := ParseUnionST_SignedTwipsMeasure(attr.Value)
@@ -159,12 +156,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.RightAttr = &parsed
 		}
 		if attr.Name.Local == "rightChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.RightCharsAttr = &pt
+			m.RightCharsAttr = &parsed
 		}
 		if attr.Name.Local == "hanging" {
 			parsed, err := ParseUnionST_TwipsMeasure(attr.Value)
@@ -174,12 +170,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.HangingAttr = &parsed
 		}
 		if attr.Name.Local == "hangingChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.HangingCharsAttr = &pt
+			m.HangingCharsAttr = &parsed
 		}
 		if attr.Name.Local == "firstLine" {
 			parsed, err := ParseUnionST_TwipsMeasure(attr.Value)
@@ -189,12 +184,11 @@ func (m *CT_Ind) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.FirstLineAttr = &parsed
 		}
 		if attr.Name.Local == "firstLineChars" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.FirstLineCharsAttr = &pt
+			m.FirstLineCharsAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_LatentStyles.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_LatentStyles.go
@@ -20,7 +20,7 @@ type CT_LatentStyles struct {
 	// Default Style Locking Setting
 	DefLockedStateAttr *sharedTypes.ST_OnOff
 	// Default User Interface Priority Setting
-	DefUIPriorityAttr *int32
+	DefUIPriorityAttr *int64
 	// Default Semi-Hidden Setting
 	DefSemiHiddenAttr *sharedTypes.ST_OnOff
 	// Default Hidden Until Used Setting
@@ -28,7 +28,7 @@ type CT_LatentStyles struct {
 	// Default Primary Style Setting
 	DefQFormatAttr *sharedTypes.ST_OnOff
 	// Latent Style Count
-	CountAttr *int32
+	CountAttr *int64
 	// Latent Style Exception
 	LsdException []*CT_LsdException
 }
@@ -85,12 +85,11 @@ func (m *CT_LatentStyles) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 			m.DefLockedStateAttr = &parsed
 		}
 		if attr.Name.Local == "defUIPriority" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.DefUIPriorityAttr = &pt
+			m.DefUIPriorityAttr = &parsed
 		}
 		if attr.Name.Local == "defSemiHidden" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)
@@ -114,12 +113,11 @@ func (m *CT_LatentStyles) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 			m.DefQFormatAttr = &parsed
 		}
 		if attr.Name.Local == "count" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CountAttr = &pt
+			m.CountAttr = &parsed
 		}
 	}
 lCT_LatentStyles:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_LineNumber.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_LineNumber.go
@@ -17,9 +17,9 @@ import (
 
 type CT_LineNumber struct {
 	// Line Number Increments to Display
-	CountByAttr *int32
+	CountByAttr *int64
 	// Line Numbering Starting Value
-	StartAttr *int32
+	StartAttr *int64
 	// Distance Between Text and Line Numbering
 	DistanceAttr *sharedTypes.ST_TwipsMeasure
 	// Line Numbering Restart Setting
@@ -62,20 +62,18 @@ func (m *CT_LineNumber) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "countBy" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CountByAttr = &pt
+			m.CountByAttr = &parsed
 		}
 		if attr.Name.Local == "start" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.StartAttr = &pt
+			m.StartAttr = &parsed
 		}
 		if attr.Name.Local == "distance" {
 			parsed, err := ParseUnionST_TwipsMeasure(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_LsdException.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_LsdException.go
@@ -21,7 +21,7 @@ type CT_LsdException struct {
 	// Latent Style Locking Setting
 	LockedAttr *sharedTypes.ST_OnOff
 	// Override default sorting order
-	UiPriorityAttr *int32
+	UiPriorityAttr *int64
 	// Semi hidden text override
 	SemiHiddenAttr *sharedTypes.ST_OnOff
 	// Unhide when used
@@ -83,12 +83,11 @@ func (m *CT_LsdException) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 			m.LockedAttr = &parsed
 		}
 		if attr.Name.Local == "uiPriority" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.UiPriorityAttr = &pt
+			m.UiPriorityAttr = &parsed
 		}
 		if attr.Name.Local == "semiHidden" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Lvl.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Lvl.go
@@ -18,7 +18,7 @@ import (
 
 type CT_Lvl struct {
 	// Numbering Level
-	IlvlAttr int32
+	IlvlAttr int64
 	// Template Code
 	TplcAttr *string
 	// Tentative Numbering
@@ -124,11 +124,11 @@ func (m *CT_Lvl) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "ilvl" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IlvlAttr = int32(parsed)
+			m.IlvlAttr = parsed
 		}
 		if attr.Name.Local == "tplc" {
 			parsed, err := attr.Value, error(nil)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Markup.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Markup.go
@@ -15,7 +15,7 @@ import (
 
 type CT_Markup struct {
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_Markup() *CT_Markup {
@@ -37,11 +37,11 @@ func (m *CT_Markup) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_MarkupRange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_MarkupRange.go
@@ -16,7 +16,7 @@ import (
 type CT_MarkupRange struct {
 	DisplacedByCustomXmlAttr ST_DisplacedByCustomXml
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_MarkupRange() *CT_MarkupRange {
@@ -48,11 +48,11 @@ func (m *CT_MarkupRange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 			m.DisplacedByCustomXmlAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_MathCtrlDel.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_MathCtrlDel.go
@@ -18,7 +18,7 @@ type CT_MathCtrlDel struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_MathCtrlDel() *CT_MathCtrlDel {
@@ -60,11 +60,11 @@ func (m *CT_MathCtrlDel) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_MathCtrlIns.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_MathCtrlIns.go
@@ -18,7 +18,7 @@ type CT_MathCtrlIns struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_MathCtrlIns() *CT_MathCtrlIns {
@@ -60,11 +60,11 @@ func (m *CT_MathCtrlIns) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_MoveBookmark.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_MoveBookmark.go
@@ -18,11 +18,11 @@ type CT_MoveBookmark struct {
 	AuthorAttr               string
 	DateAttr                 time.Time
 	NameAttr                 string
-	ColFirstAttr             *int32
-	ColLastAttr              *int32
+	ColFirstAttr             *int64
+	ColLastAttr              *int64
 	DisplacedByCustomXmlAttr ST_DisplacedByCustomXml
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_MoveBookmark() *CT_MoveBookmark {
@@ -86,30 +86,28 @@ func (m *CT_MoveBookmark) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 			m.NameAttr = parsed
 		}
 		if attr.Name.Local == "colFirst" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColFirstAttr = &pt
+			m.ColFirstAttr = &parsed
 		}
 		if attr.Name.Local == "colLast" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColLastAttr = &pt
+			m.ColLastAttr = &parsed
 		}
 		if attr.Name.Local == "displacedByCustomXml" {
 			m.DisplacedByCustomXmlAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Num.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Num.go
@@ -16,7 +16,7 @@ import (
 
 type CT_Num struct {
 	// Numbering Definition Instance ID
-	NumIdAttr int32
+	NumIdAttr int64
 	// Abstract Numbering Definition Reference
 	AbstractNumId *CT_DecimalNumber
 	// Numbering Level Definition Override
@@ -50,11 +50,11 @@ func (m *CT_Num) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	m.AbstractNumId = NewCT_DecimalNumber()
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "numId" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.NumIdAttr = int32(parsed)
+			m.NumIdAttr = parsed
 		}
 	}
 lCT_Num:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_NumLvl.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_NumLvl.go
@@ -16,7 +16,7 @@ import (
 
 type CT_NumLvl struct {
 	// Numbering Level ID
-	IlvlAttr int32
+	IlvlAttr int64
 	// Numbering Level Starting Value Override
 	StartOverride *CT_DecimalNumber
 	// Numbering Level Override Definition
@@ -50,11 +50,11 @@ func (m *CT_NumLvl) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "ilvl" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IlvlAttr = int32(parsed)
+			m.IlvlAttr = parsed
 		}
 	}
 lCT_NumLvl:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_NumPicBullet.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_NumPicBullet.go
@@ -16,7 +16,7 @@ import (
 
 type CT_NumPicBullet struct {
 	// Picture Numbering Symbol ID
-	NumPicBulletIdAttr int32
+	NumPicBulletIdAttr int64
 	// Picture Numbering Symbol Properties
 	Pict    *CT_Picture
 	Drawing *CT_Drawing
@@ -49,11 +49,11 @@ func (m *CT_NumPicBullet) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "numPicBulletId" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.NumPicBulletIdAttr = int32(parsed)
+			m.NumPicBulletIdAttr = parsed
 		}
 	}
 lCT_NumPicBullet:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_PPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_PPrChange.go
@@ -19,7 +19,7 @@ type CT_PPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	PPr    *CT_PPrBase
 }
 
@@ -66,11 +66,11 @@ func (m *CT_PPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_PPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_PageNumber.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_PageNumber.go
@@ -17,9 +17,9 @@ type CT_PageNumber struct {
 	// Page Number Format
 	FmtAttr ST_NumberFormat
 	// Starting Page Number
-	StartAttr *int32
+	StartAttr *int64
 	// Chapter Heading Style
-	ChapStyleAttr *int32
+	ChapStyleAttr *int64
 	// Chapter Separator Character
 	ChapSepAttr ST_ChapterSep
 }
@@ -66,20 +66,18 @@ func (m *CT_PageNumber) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 			m.FmtAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "start" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.StartAttr = &pt
+			m.StartAttr = &parsed
 		}
 		if attr.Name.Local == "chapStyle" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ChapStyleAttr = &pt
+			m.ChapStyleAttr = &parsed
 		}
 		if attr.Name.Local == "chapSep" {
 			m.ChapSepAttr.UnmarshalXMLAttr(attr)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_PageSz.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_PageSz.go
@@ -23,7 +23,7 @@ type CT_PageSz struct {
 	// Page Orientation
 	OrientAttr ST_PageOrientation
 	// Printer Paper Code
-	CodeAttr *int32
+	CodeAttr *int64
 }
 
 func NewCT_PageSz() *CT_PageSz {
@@ -79,12 +79,11 @@ func (m *CT_PageSz) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			m.OrientAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "code" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CodeAttr = &pt
+			m.CodeAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_PaperSource.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_PaperSource.go
@@ -15,9 +15,9 @@ import (
 
 type CT_PaperSource struct {
 	// First Page Printer Tray Code
-	FirstAttr *int32
+	FirstAttr *int64
 	// Non-First Page Printer Tray Code
-	OtherAttr *int32
+	OtherAttr *int64
 }
 
 func NewCT_PaperSource() *CT_PaperSource {
@@ -45,20 +45,18 @@ func (m *CT_PaperSource) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	// initialize to default
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "first" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.FirstAttr = &pt
+			m.FirstAttr = &parsed
 		}
 		if attr.Name.Local == "other" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.OtherAttr = &pt
+			m.OtherAttr = &parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_ParaRPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_ParaRPrChange.go
@@ -19,7 +19,7 @@ type CT_ParaRPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	RPr    *CT_ParaRPrOriginal
 }
 
@@ -66,11 +66,11 @@ func (m *CT_ParaRPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_ParaRPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_PermStart.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_PermStart.go
@@ -16,8 +16,8 @@ import (
 type CT_PermStart struct {
 	EdGrpAttr    ST_EdGrp
 	EdAttr       *string
-	ColFirstAttr *int32
-	ColLastAttr  *int32
+	ColFirstAttr *int64
+	ColLastAttr  *int64
 	// Annotation ID
 	IdAttr string
 	// Annotation Displaced By Custom XML Markup
@@ -79,20 +79,18 @@ func (m *CT_PermStart) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 			m.EdAttr = &parsed
 		}
 		if attr.Name.Local == "colFirst" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColFirstAttr = &pt
+			m.ColFirstAttr = &parsed
 		}
 		if attr.Name.Local == "colLast" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.ColLastAttr = &pt
+			m.ColLastAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
 			parsed, err := attr.Value, error(nil)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_RPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_RPrChange.go
@@ -19,7 +19,7 @@ type CT_RPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	RPr    *CT_RPrOriginal
 }
 
@@ -66,11 +66,11 @@ func (m *CT_RPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_RPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_RunTrackChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_RunTrackChange.go
@@ -18,7 +18,7 @@ type CT_RunTrackChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_RunTrackChange() *CT_RunTrackChange {
@@ -60,11 +60,11 @@ func (m *CT_RunTrackChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_SectPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_SectPrChange.go
@@ -19,7 +19,7 @@ type CT_SectPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	SectPr *CT_SectPrBase
 }
 
@@ -66,11 +66,11 @@ func (m *CT_SectPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_SectPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_Spacing.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_Spacing.go
@@ -19,13 +19,13 @@ type CT_Spacing struct {
 	// Spacing Above Paragraph
 	BeforeAttr *sharedTypes.ST_TwipsMeasure
 	// Spacing Above Paragraph IN Line Units
-	BeforeLinesAttr *int32
+	BeforeLinesAttr *int64
 	// Automatically Determine Spacing Above Paragraph
 	BeforeAutospacingAttr *sharedTypes.ST_OnOff
 	// Spacing Below Paragraph
 	AfterAttr *sharedTypes.ST_TwipsMeasure
 	// Spacing Below Paragraph in Line Units
-	AfterLinesAttr *int32
+	AfterLinesAttr *int64
 	// Automatically Determine Spacing Below Paragraph
 	AfterAutospacingAttr *sharedTypes.ST_OnOff
 	// Spacing Between Lines in Paragraph
@@ -93,12 +93,11 @@ func (m *CT_Spacing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.BeforeAttr = &parsed
 		}
 		if attr.Name.Local == "beforeLines" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.BeforeLinesAttr = &pt
+			m.BeforeLinesAttr = &parsed
 		}
 		if attr.Name.Local == "beforeAutospacing" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)
@@ -115,12 +114,11 @@ func (m *CT_Spacing) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 			m.AfterAttr = &parsed
 		}
 		if attr.Name.Local == "afterLines" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.AfterLinesAttr = &pt
+			m.AfterLinesAttr = &parsed
 		}
 		if attr.Name.Local == "afterAutospacing" {
 			parsed, err := ParseUnionST_OnOff(attr.Value)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblGridChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblGridChange.go
@@ -16,7 +16,7 @@ import (
 
 type CT_TblGridChange struct {
 	// Annotation Identifier
-	IdAttr  int32
+	IdAttr  int64
 	TblGrid *CT_TblGridBase
 }
 
@@ -43,11 +43,11 @@ func (m *CT_TblGridChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 	m.TblGrid = NewCT_TblGridBase()
 	for _, attr := range start.Attr {
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_TblGridChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblPrChange.go
@@ -19,7 +19,7 @@ type CT_TblPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	TblPr  *CT_TblPrBase
 }
 
@@ -66,11 +66,11 @@ func (m *CT_TblPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_TblPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblPrExChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TblPrExChange.go
@@ -19,7 +19,7 @@ type CT_TblPrExChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr  int32
+	IdAttr  int64
 	TblPrEx *CT_TblPrExBase
 }
 
@@ -66,11 +66,11 @@ func (m *CT_TblPrExChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_TblPrExChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TcPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TcPrChange.go
@@ -19,7 +19,7 @@ type CT_TcPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	TcPr   *CT_TcPrInner
 }
 
@@ -66,11 +66,11 @@ func (m *CT_TcPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_TcPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrPrChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrPrChange.go
@@ -19,7 +19,7 @@ type CT_TrPrChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 	TrPr   *CT_TrPrBase
 }
 
@@ -66,11 +66,11 @@ func (m *CT_TrPrChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 lCT_TrPrChange:

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChange.go
@@ -18,7 +18,7 @@ type CT_TrackChange struct {
 	AuthorAttr string
 	DateAttr   *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_TrackChange() *CT_TrackChange {
@@ -60,11 +60,11 @@ func (m *CT_TrackChange) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChangeNumbering.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChangeNumbering.go
@@ -19,7 +19,7 @@ type CT_TrackChangeNumbering struct {
 	AuthorAttr   string
 	DateAttr     *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_TrackChangeNumbering() *CT_TrackChangeNumbering {
@@ -72,11 +72,11 @@ func (m *CT_TrackChangeNumbering) UnmarshalXML(d *xml.Decoder, start xml.StartEl
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChangeRange.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_TrackChangeRange.go
@@ -19,7 +19,7 @@ type CT_TrackChangeRange struct {
 	AuthorAttr               string
 	DateAttr                 *time.Time
 	// Annotation Identifier
-	IdAttr int32
+	IdAttr int64
 }
 
 func NewCT_TrackChangeRange() *CT_TrackChangeRange {
@@ -72,11 +72,11 @@ func (m *CT_TrackChangeRange) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 			m.DateAttr = &parsed
 		}
 		if attr.Name.Local == "id" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.IdAttr = int32(parsed)
+			m.IdAttr = parsed
 		}
 	}
 	// skip any extensions we may find, but don't support

--- a/schema/schemas.openxmlformats.org/wordprocessingml/CT_WriteProtection.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/CT_WriteProtection.go
@@ -21,8 +21,8 @@ type CT_WriteProtection struct {
 	CryptProviderTypeAttr          sharedTypes.ST_CryptProv
 	CryptAlgorithmClassAttr        sharedTypes.ST_AlgClass
 	CryptAlgorithmTypeAttr         sharedTypes.ST_AlgType
-	CryptAlgorithmSidAttr          *int32
-	CryptSpinCountAttr             *int32
+	CryptAlgorithmSidAttr          *int64
+	CryptSpinCountAttr             *int64
 	CryptProviderAttr              *string
 	AlgIdExtAttr                   *string
 	AlgIdExtSourceAttr             *string
@@ -126,20 +126,18 @@ func (m *CT_WriteProtection) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 			m.CryptAlgorithmTypeAttr.UnmarshalXMLAttr(attr)
 		}
 		if attr.Name.Local == "cryptAlgorithmSid" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptAlgorithmSidAttr = &pt
+			m.CryptAlgorithmSidAttr = &parsed
 		}
 		if attr.Name.Local == "cryptSpinCount" {
-			parsed, err := strconv.ParseInt(attr.Value, 10, 32)
+			parsed, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			pt := int32(parsed)
-			m.CryptSpinCountAttr = &pt
+			m.CryptSpinCountAttr = &parsed
 		}
 		if attr.Name.Local == "cryptProvider" {
 			parsed, err := attr.Value, error(nil)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/ST_DecimalNumberOrPercent.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/ST_DecimalNumberOrPercent.go
@@ -13,7 +13,7 @@ import (
 
 // ST_DecimalNumberOrPercent is a union type
 type ST_DecimalNumberOrPercent struct {
-	ST_UnqualifiedPercentage *int32
+	ST_UnqualifiedPercentage *int64
 	ST_Percentage            *string
 }
 

--- a/schema/schemas.openxmlformats.org/wordprocessingml/ST_SignedHpsMeasure.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/ST_SignedHpsMeasure.go
@@ -13,7 +13,7 @@ import (
 
 // ST_SignedHpsMeasure is a union type
 type ST_SignedHpsMeasure struct {
-	Int32               *int32
+	Int64               *int64
 	ST_UniversalMeasure *string
 }
 
@@ -22,8 +22,8 @@ func (m *ST_SignedHpsMeasure) Validate() error {
 }
 func (m *ST_SignedHpsMeasure) ValidateWithPath(path string) error {
 	mems := []string{}
-	if m.Int32 != nil {
-		mems = append(mems, "Int32")
+	if m.Int64 != nil {
+		mems = append(mems, "Int64")
 	}
 	if m.ST_UniversalMeasure != nil {
 		mems = append(mems, "ST_UniversalMeasure")
@@ -34,8 +34,8 @@ func (m *ST_SignedHpsMeasure) ValidateWithPath(path string) error {
 	return nil
 }
 func (m ST_SignedHpsMeasure) String() string {
-	if m.Int32 != nil {
-		return fmt.Sprintf("%v", *m.Int32)
+	if m.Int64 != nil {
+		return fmt.Sprintf("%v", *m.Int64)
 	}
 	if m.ST_UniversalMeasure != nil {
 		return fmt.Sprintf("%v", *m.ST_UniversalMeasure)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/ST_SignedTwipsMeasure.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/ST_SignedTwipsMeasure.go
@@ -13,7 +13,7 @@ import (
 
 // ST_SignedTwipsMeasure is a union type
 type ST_SignedTwipsMeasure struct {
-	Int32               *int32
+	Int64               *int64
 	ST_UniversalMeasure *string
 }
 
@@ -22,8 +22,8 @@ func (m *ST_SignedTwipsMeasure) Validate() error {
 }
 func (m *ST_SignedTwipsMeasure) ValidateWithPath(path string) error {
 	mems := []string{}
-	if m.Int32 != nil {
-		mems = append(mems, "Int32")
+	if m.Int64 != nil {
+		mems = append(mems, "Int64")
 	}
 	if m.ST_UniversalMeasure != nil {
 		mems = append(mems, "ST_UniversalMeasure")
@@ -34,8 +34,8 @@ func (m *ST_SignedTwipsMeasure) ValidateWithPath(path string) error {
 	return nil
 }
 func (m ST_SignedTwipsMeasure) String() string {
-	if m.Int32 != nil {
-		return fmt.Sprintf("%v", *m.Int32)
+	if m.Int64 != nil {
+		return fmt.Sprintf("%v", *m.Int64)
 	}
 	if m.ST_UniversalMeasure != nil {
 		return fmt.Sprintf("%v", *m.ST_UniversalMeasure)

--- a/schema/schemas.openxmlformats.org/wordprocessingml/ST_TextScale.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/ST_TextScale.go
@@ -14,7 +14,7 @@ import (
 // ST_TextScale is a union type
 type ST_TextScale struct {
 	ST_TextScalePercent *string
-	ST_TextScaleDecimal *int32
+	ST_TextScaleDecimal *int64
 }
 
 func (m *ST_TextScale) Validate() error {

--- a/schema/schemas.openxmlformats.org/wordprocessingml/common.go
+++ b/schema/schemas.openxmlformats.org/wordprocessingml/common.go
@@ -35,8 +35,7 @@ func ParseUnionST_SignedTwipsMeasure(s string) (ST_SignedTwipsMeasure, error) {
 		if err != nil {
 			return r, fmt.Errorf("parsing %s as int: %s", s, err)
 		}
-		v32 := int32(v)
-		r.Int32 = &v32
+		r.Int64 = &v
 	}
 	return r, nil
 }
@@ -82,8 +81,7 @@ func ParseUnionST_DecimalNumberOrPercent(s string) (ST_DecimalNumberOrPercent, e
 		if err != nil {
 			return ret, fmt.Errorf("parsing %s as int: %s", s, err)
 		}
-		v32 := int32(v)
-		ret.ST_UnqualifiedPercentage = &v32
+		ret.ST_UnqualifiedPercentage = &v
 	}
 	return ret, nil
 }
@@ -101,8 +99,7 @@ func ParseUnionST_MeasurementOrPercent(s string) (ST_MeasurementOrPercent, error
 			if err != nil {
 				return r, fmt.Errorf("parsing %s as int: %s", s, err)
 			}
-			v32 := int32(v)
-			r.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = &v32
+			r.ST_DecimalNumberOrPercent.ST_UnqualifiedPercentage = &v
 		}
 	}
 	return r, nil
@@ -132,8 +129,7 @@ func ParseUnionST_SignedHpsMeasure(s string) (ST_SignedHpsMeasure, error) {
 		if err != nil {
 			return r, fmt.Errorf("parsing %s as int: %s", s, err)
 		}
-		v32 := int32(v)
-		r.Int32 = &v32
+		r.Int64 = &v
 	}
 	return r, nil
 }
@@ -147,8 +143,7 @@ func ParseUnionST_TextScale(s string) (ST_TextScale, error) {
 		if err != nil {
 			return r, fmt.Errorf("parsing %s as int: %s", s, err)
 		}
-		v32 := int32(v)
-		r.ST_TextScaleDecimal = &v32
+		r.ST_TextScaleDecimal = &v
 	}
 	return r, nil
 }


### PR DESCRIPTION
It's arbitrary precision per XSD, so may have to change again. Treating it as a 64 bit value for now.