### PR TITLE
spreadsheet: record inf/nan as errors

### DIFF
--- a/spreadsheet/cell.go
+++ b/spreadsheet/cell.go
@@ -115,9 +115,16 @@ func (c Cell) SetStringByID(id int) {
 // SetNumber sets the cell type to number, and the value to the given number
 func (c Cell) SetNumber(v float64) {
 	c.clearValue()
-	c.x.V = gooxml.String(strconv.FormatFloat(v, 'g', -1, 64))
+	// NaN / Infinity
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		c.x.TAttr = sml.ST_CellTypeE
+		c.x.V = gooxml.String("#NUM!")
+		return
+	}
+
 	// cell type number
 	c.x.TAttr = sml.ST_CellTypeN
+	c.x.V = gooxml.String(strconv.FormatFloat(v, 'g', -1, 64))
 }
 
 func (c Cell) getFormat() string {

--- a/spreadsheet/sheet_test.go
+++ b/spreadsheet/sheet_test.go
@@ -8,6 +8,7 @@
 package spreadsheet_test
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 
@@ -227,5 +228,27 @@ func TestFormattedCell(t *testing.T) {
 			t.Errorf("expected %s in cell %s, got %s", tc.Exp, tc.Cell, got)
 		}
 	}
-	_ = wb
+}
+
+func TestInfNan(t *testing.T) {
+	wb := spreadsheet.New()
+	sheet := wb.AddSheet()
+	sheet.Cell("A1").SetNumber(math.NaN())
+
+	rv, err := sheet.Cell("A1").GetRawValue()
+	if err != nil {
+		t.Errorf("got error: %s", err)
+	}
+	if rv != "#NUM!" {
+		t.Error("expected error for NaN")
+	}
+
+	sheet.Cell("A1").SetNumber(math.Inf(1))
+	rv, err = sheet.Cell("A1").GetRawValue()
+	if err != nil {
+		t.Errorf("got error: %s", err)
+	}
+	if rv != "#NUM!" {
+		t.Error("expected error for NaN")
+	}
 }


### PR DESCRIPTION
As you can't directly enter NaN/Inf in Excel, there's
no great way to verify behavior.  This just ensures
that setting NaN/Inf from Go will result in a #NUM!
error in Excel.