### PR TITLE
common: use path.Clean instead of filepath.Clean

### DIFF
--- a/presentation/presentation.go
+++ b/presentation/presentation.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
 
 	"baliance.com/gooxml"
 	"baliance.com/gooxml/common"
@@ -596,7 +596,9 @@ func (p *Presentation) onNewRelationship(decMap *zippkg.DecodeMap, target, typ s
 		p.themeRels = append(p.themeRels, thmRel)
 
 	case gooxml.ImageType:
-		target = filepath.Clean(target)
+		// we use path.Clean instead of filepath.Clean to ensure we
+		// end up with forward separators
+		target = path.Clean(target)
 		for i, f := range files {
 			if f == nil {
 				continue

--- a/zippkg/decodemap.go
+++ b/zippkg/decodemap.go
@@ -9,7 +9,7 @@ package zippkg
 
 import (
 	"archive/zip"
-	"path/filepath"
+	"path"
 
 	"baliance.com/gooxml/schema/soo/pkg/relationships"
 )
@@ -64,7 +64,10 @@ func (d *DecodeMap) AddTarget(filePath string, ifc interface{}, sourceFileType s
 		d.decoded = make(map[string]struct{})
 		d.indices = make(map[string]int)
 	}
-	fn := filepath.Clean(filePath)
+
+	// we use path.Clean instead of filepath.Clean to ensure we
+	// end up with forward separators
+	fn := path.Clean(filePath)
 	if _, ok := d.decoded[fn]; ok {
 		// already decoded this file
 		return false
@@ -117,7 +120,10 @@ func (d *DecodeMap) Decode(files []*zip.File) error {
 					d.rels = append(d.rels, dest)
 					// find the path that any files mentioned in the
 					// relationships file are relative to
-					basePath, _ := filepath.Split(filepath.Clean(f.Name + "/../"))
+
+					// we use path.Clean instead of filepath.Clean to ensure we
+					// end up with forward separators
+					basePath, _ := path.Split(path.Clean(f.Name + "/../"))
 					d.basePaths[drel] = basePath
 					// ensure we make another decode pass
 					pass++


### PR DESCRIPTION
This ensures correctly formatted relative filenames on
Windows.  filepath.Clean uses the system seprator character,
while path.Clean always uses a forward slash.

Thanks to @AlexeyUzhva for noticing.

Fixes #146