### PR TITLE
document: fix IsBold check

### DIFF
--- a/document/onoffvalue.go
+++ b/document/onoffvalue.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Baliance. All rights reserved.
+//
+// Use of this source code is governed by the terms of the Affero GNU General
+// Public License version 3.0 as published by the Free Software Foundation and
+// appearing in the file LICENSE included in the packaging of this file. A
+// commercial license can be purchased by contacting sales@baliance.com.
+
+package document
+
+import "baliance.com/gooxml/schema/soo/wml"
+
+// OnOffValue represents an on/off value that can also be unset
+type OnOffValue byte
+
+// OnOffValue constants
+const (
+	OnOffValueUnset OnOffValue = iota
+	OnOffValueOff
+	OnOffValueOn
+)
+
+func convertOnOff(v *wml.CT_OnOff) OnOffValue {
+	if v == nil {
+		return OnOffValueUnset
+	}
+	// set, but the value is set to false
+	if v.ValAttr != nil && v.ValAttr.Bool != nil && *v.ValAttr.Bool == false {
+		return OnOffValueOff
+	}
+	// element exists, which implies turned on (and boolean value can't be false)
+	return OnOffValueOn
+}

--- a/document/run_test.go
+++ b/document/run_test.go
@@ -5,16 +5,18 @@
 // appearing in the file LICENSE included in the packaging of this file. A
 // commercial license can be purchased by contacting sales@baliance.com.
 
-package document_test
+package document
 
 import (
 	"testing"
 
-	"baliance.com/gooxml/document"
+	"baliance.com/gooxml"
+	"baliance.com/gooxml/schema/soo/ofc/sharedTypes"
+	"baliance.com/gooxml/schema/soo/wml"
 )
 
 func TestRunClear(t *testing.T) {
-	doc := document.New()
+	doc := New()
 	para := doc.AddParagraph()
 	run := para.AddRun()
 	if len(run.X().EG_RunInnerContent) != 0 {
@@ -33,5 +35,30 @@ func TestRunClear(t *testing.T) {
 	run.Clear()
 	if len(run.X().EG_RunInnerContent) != 0 {
 		t.Errorf("expected inner content of length zero, had %d", len(run.X().EG_RunInnerContent))
+	}
+}
+
+// Issue #204
+func TestRunPropertiesBold(t *testing.T) {
+	r := RunProperties{wml.NewCT_RPr()}
+	if r.IsBold() {
+		t.Errorf("expected IsBold = false with no bold element")
+	}
+	r.x.B = wml.NewCT_OnOff()
+	r.x.B.ValAttr = &sharedTypes.ST_OnOff{}
+	r.x.B.ValAttr.Bool = gooxml.Bool(false)
+
+	if r.IsBold() {
+		t.Errorf("expected IsBold = false with false bool value")
+	}
+
+	r.x.B.ValAttr.Bool = gooxml.Bool(true)
+	if !r.IsBold() {
+		t.Errorf("expected IsBold = true with true bool value")
+	}
+
+	r.x.B = wml.NewCT_OnOff()
+	if !r.IsBold() {
+		t.Errorf("expected IsBold = true with existence and no bool value")
 	}
 }

--- a/document/runproperties.go
+++ b/document/runproperties.go
@@ -93,9 +93,14 @@ func (r RunProperties) SetUnderline(style wml.ST_Underline, c color.Color) {
 	}
 }
 
+// BoldValue returns the precise nature of the bold setting (unset, off or on).
+func (r RunProperties) BoldValue() OnOffValue {
+	return convertOnOff(r.x.B)
+}
+
 // IsBold returns true if the run has been set to bold.
 func (r RunProperties) IsBold() bool {
-	return r.x.B != nil
+	return r.BoldValue() == OnOffValueOn
 }
 
 // SetBold sets the run to bold.
@@ -109,12 +114,14 @@ func (r RunProperties) SetBold(b bool) {
 	}
 }
 
-// IsItalic returns true if the run was set to bold.
+// ItalicValue returns the precise nature of the italic setting (unset, off or on).
+func (r RunProperties) ItalicValue() OnOffValue {
+	return convertOnOff(r.x.I)
+}
+
+// IsItalic returns true if the run has been set to italics.
 func (r RunProperties) IsItalic() bool {
-	if r.x == nil {
-		return false
-	}
-	return r.x.I != nil
+	return r.ItalicValue() == OnOffValueOn
 }
 
 // SetItalic sets the run to italic.


### PR DESCRIPTION
We used existence to indicate non-boldness, but the element
can exist with a false value which also means bold is disabled.

Fixes #204