### PR TITLE
spreadsheet: add a RemoveCalcChain function

### DIFF
--- a/common/relationships.go
+++ b/common/relationships.go
@@ -85,6 +85,18 @@ func (r Relationships) AddRelationship(target, ctype string) Relationship {
 	return Relationship{rel}
 }
 
+// Remove removes an existing relationship.
+func (r Relationships) Remove(rel Relationship) bool {
+	for i, ir := range r.x.Relationship {
+		if ir == rel.x {
+			copy(r.x.Relationship[i:], r.x.Relationship[i+1:])
+			r.x.Relationship = r.x.Relationship[0 : len(r.x.Relationship)-1]
+			return true
+		}
+	}
+	return false
+}
+
 // Hyperlink is just an appropriately configured relationship.
 type Hyperlink Relationship
 

--- a/common/relationships_test.go
+++ b/common/relationships_test.go
@@ -89,3 +89,38 @@ func TestRelationshipsCreationUnordered(t *testing.T) {
 	}
 
 }
+
+func TestRelationshipsRemoval(t *testing.T) {
+	r := common.NewRelationships()
+	r.AddRelationship("foo1", "http://bar")
+	r.AddRelationship("foo2", "http://bar")
+	r.AddRelationship("foo3", "http://bar")
+
+	if len(r.Relationships()) != 3 {
+		t.Errorf("expected 3, got %d", len(r.Relationships()))
+	}
+	r.Remove(r.Relationships()[0])
+
+	if len(r.Relationships()) != 2 {
+		t.Errorf("expected 2, got %d", len(r.Relationships()))
+	}
+	if got := r.Relationships()[0].Target(); got != "foo2" {
+		t.Errorf("expected foo2, got %s", got)
+	}
+	if got := r.Relationships()[1].Target(); got != "foo3" {
+		t.Errorf("expected foo3, got %s", got)
+	}
+	r.Remove(r.Relationships()[1])
+
+	if len(r.Relationships()) != 1 {
+		t.Errorf("expected 1, got %d", len(r.Relationships()))
+	}
+	if got := r.Relationships()[0].Target(); got != "foo2" {
+		t.Errorf("expected foo2, got %s", got)
+	}
+
+	r.Remove(r.Relationships()[0])
+	if len(r.Relationships()) != 0 {
+		t.Errorf("expected 0, got %d", len(r.Relationships()))
+	}
+}

--- a/spreadsheet/workbook.go
+++ b/spreadsheet/workbook.go
@@ -579,3 +579,28 @@ func (wb *Workbook) Close() error {
 	}
 	return nil
 }
+
+// RemoveCalcChain removes the cached caculation chain. This is sometimes needed
+// as we don't update it when rows are added/removed.
+func (wb *Workbook) RemoveCalcChain() {
+	var calcFile string
+	for _, r := range wb.wbRels.Relationships() {
+		if r.Type() == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain" {
+			calcFile = "xl/" + r.Target()
+			wb.wbRels.Remove(r)
+			break
+		}
+	}
+
+	if calcFile == "" {
+		return
+	}
+	wb.ContentTypes.RemoveOverride(calcFile)
+	for i, x := range wb.ExtraFiles {
+		if x.ZipPath == calcFile {
+			wb.ExtraFiles[i] = wb.ExtraFiles[len(wb.ExtraFiles)-1]
+			wb.ExtraFiles = wb.ExtraFiles[:len(wb.ExtraFiles)-1]
+			return
+		}
+	}
+}


### PR DESCRIPTION
This allows removing the cached calculation change which
can contain bad data if rows are inserted/removed.

Fixes #215