### PR TITLE
Various new document methods

### DIFF
--- a/document/numberingdefinition.go
+++ b/document/numberingdefinition.go
@@ -37,7 +37,27 @@ func (n NumberingDefinition) Levels() []NumberingLevel {
 // AddLevel adds a new numbering level to a NumberingDefinition.
 func (n NumberingDefinition) AddLevel() NumberingLevel {
 	nl := wml.NewCT_Lvl()
+	nl.Start = &wml.CT_DecimalNumber{ValAttr: 1}
 	nl.IlvlAttr = int64(len(n.x.Lvl))
 	n.x.Lvl = append(n.x.Lvl, nl)
 	return NumberingLevel{nl}
+}
+
+// MultiLevelType returns the multilevel type, or ST_MultiLevelTypeUnset if not set.
+func (n NumberingDefinition) MultiLevelType() wml.ST_MultiLevelType {
+	if n.x.MultiLevelType != nil {
+		return n.x.MultiLevelType.ValAttr
+	} else {
+		return wml.ST_MultiLevelTypeUnset
+	}
+}
+
+// SetMultiLevelType sets the multilevel type.
+func (n NumberingDefinition) SetMultiLevelType(t wml.ST_MultiLevelType) {
+	if t == wml.ST_MultiLevelTypeUnset {
+		n.x.MultiLevelType = nil
+	} else {
+		n.x.MultiLevelType = wml.NewCT_MultiLevelType()
+		n.x.MultiLevelType.ValAttr = t
+	}
 }

--- a/document/paragraphstyleproperties.go
+++ b/document/paragraphstyleproperties.go
@@ -24,6 +24,16 @@ func (p ParagraphStyleProperties) X() *wml.CT_PPrGeneral {
 	return p.x
 }
 
+// SetAlignment controls the paragraph alignment
+func (p ParagraphStyleProperties) SetAlignment(align wml.ST_Jc) {
+	if align == wml.ST_JcUnset {
+		p.x.Jc = nil
+	} else {
+		p.x.Jc = wml.NewCT_Jc()
+		p.x.Jc.ValAttr = align
+	}
+}
+
 // AddTabStop adds a tab stop to the paragraph.
 func (p ParagraphStyleProperties) AddTabStop(position measurement.Distance, justificaton wml.ST_TabJc, leader wml.ST_TabTlc) {
 	if p.x.Tabs == nil {
@@ -102,5 +112,30 @@ func (p ParagraphStyleProperties) SetLeftIndent(m measurement.Distance) {
 	} else {
 		p.x.Ind.LeftAttr = &wml.ST_SignedTwipsMeasure{}
 		p.x.Ind.LeftAttr.Int64 = gooxml.Int64(int64(m / measurement.Twips))
+	}
+}
+
+// SetStartIndent controls the start indent of the paragraph.
+func (p ParagraphStyleProperties) SetStartIndent(m measurement.Distance) {
+	if p.x.Ind == nil {
+		p.x.Ind = wml.NewCT_Ind()
+	}
+	if m == measurement.Zero {
+		p.x.Ind.StartAttr = nil
+	} else {
+		p.x.Ind.StartAttr = &wml.ST_SignedTwipsMeasure{}
+		p.x.Ind.StartAttr.Int64 = gooxml.Int64(int64(m / measurement.Twips))
+	}
+}
+// SetHangingIndent controls the hanging indent of the paragraph.
+func (p ParagraphStyleProperties) SetHangingIndent(m measurement.Distance) {
+	if p.x.Ind == nil {
+		p.x.Ind = wml.NewCT_Ind()
+	}
+	if m == measurement.Zero {
+		p.x.Ind.HangingAttr = nil
+	} else {
+		p.x.Ind.HangingAttr = &sharedTypes.ST_TwipsMeasure{}
+		p.x.Ind.HangingAttr.ST_UnsignedDecimalNumber = gooxml.Uint64(uint64(m / measurement.Twips))
 	}
 }

--- a/document/run.go
+++ b/document/run.go
@@ -126,6 +126,13 @@ func (r Run) AddBreak() {
 	ic.Br = wml.NewCT_Br()
 }
 
+// AddPageBreak adds a page break to a run.
+func (r Run) AddPageBreak() {
+	ic := r.newIC()
+	ic.Br = wml.NewCT_Br()
+	ic.Br.TypeAttr = wml.ST_BrTypePage
+}
+
 // DrawingAnchored returns a slice of AnchoredDrawings.
 func (r Run) DrawingAnchored() []AnchoredDrawing {
 	ret := []AnchoredDrawing{}


### PR DESCRIPTION
* Set and get MultiLevelType.
* NumberingLevel now starts numbering at 1 by default, not 0.
* SetAlignment(), SetStartIndent() and SetHangingIndent() in ParagraphStyleProperties - useful for list formatting.
* Run.AddPageBreak()