### PR TITLE
Sdt cells

### DIFF
--- a/document/row.go
+++ b/document/row.go
@@ -46,6 +46,11 @@ func (r Row) Cells() []Cell {
 		for _, ctCell := range cc.Tc {
 			ret = append(ret, Cell{r.d, ctCell})
 		}
+		if cc.Sdt != nil && cc.Sdt.SdtContent != nil {
+			for _, ctCell := range cc.Sdt.SdtContent.Tc {
+				ret = append(ret, Cell{r.d, ctCell})
+			}
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
Table cells can be found also in the `Sdt` field for `EG_ContentCellContent`. This PR includes in `row.Cells()` cells found in this location.

Note that this same corner case seems to apply to [rows as well](https://github.com/baliance/gooxml/blob/master/schema/soo/wml/EG_ContentRowContent.go#L26). Let me know if you'd like a PR for that too.

Here is the file showing the issue: 
[checkboxes.docx](https://github.com/baliance/gooxml/files/3036218/checkboxes.docx)

